### PR TITLE
Homework1: helper function run_in_transaction

### DIFF
--- a/PostgreSQL-Students-[Docker].ipynb
+++ b/PostgreSQL-Students-[Docker].ipynb
@@ -141,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip list # verify psycopg2-binary is installed"
+    "! pip install psycopg2"
    ]
   },
   {
@@ -320,6 +320,32 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Queries that change the database structure (create table, alter table, drop table) \n",
+    "# or modify data (insert, update, delete) must run within a transaction.\n",
+    "# Use this helper function when executing such statements\n",
+    "\n",
+    "# Do not use this for select queries\n",
+    "\n",
+    "    \n",
+    "def run_in_transaction(con, sql):\n",
+    "    try:\n",
+    "        cursor = con.cursor()\n",
+    "        cursor.execute(sql);\n",
+    "        con.commit()\n",
+    "        print (\"Query executed successfully!\")\n",
+    "    except (Exception, psycopg2.Error) as error :\n",
+    "        print(\"Error While executing query: \", error)\n",
+    "        con.rollback()\n",
+    "    finally:\n",
+    "        cursor.close()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -334,26 +360,15 @@
    "source": [
     "#Create \"Customer\" Table\n",
     "\n",
-    "try:\n",
-    "    #table_name variable\n",
-    "    customerTable=\"customer\"\n",
-    "    create_customerTablee_query = '''CREATE TABLE '''+ customerTable+''' \n",
-    "              (id INT  PRIMARY KEY     NOT NULL,\n",
-    "               name           TEXT    NOT NULL,\n",
-    "               country        TEXT    NOT NULL,\n",
-    "               email          TEXT   \n",
-    "               ); '''\n",
-    "\n",
-    "    #Execute this command (SQL Query)\n",
-    "    cursor.execute(create_customerTablee_query)\n",
-    "    \n",
-    "    # Make the changes to the database persistent\n",
-    "    con.commit()\n",
-    "    print(\"Table (\"+ customerTable +\") created successfully in PostgreSQL \")\n",
-    "except (Exception, psycopg2.Error) as error:\n",
-    "    # if it exits with an exception the transaction is rolled back.\n",
-    "    con.rollback()\n",
-    "    print(\"Error While Creating the DB: \",error)\n"
+    "run_in_transaction(con, \"\"\"\n",
+    "    CREATE TABLE customer (\n",
+    "        id INT PRIMARY KEY NOT NULL,\n",
+    "        name TEXT NOT NULL,\n",
+    "        country TEXT NOT NULL,\n",
+    "        email TEXT\n",
+    "    );\n",
+    "\"\"\")\n",
+    "\n"
    ]
   },
   {

--- a/PostgreSQL-Students.ipynb
+++ b/PostgreSQL-Students.ipynb
@@ -346,6 +346,32 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Queries that change the database structure (create table, alter table, drop table) \n",
+    "# or modify data (insert, update, delete) must run within a transaction.\n",
+    "# Use this helper function when executing such statements\n",
+    "\n",
+    "# Do not use this for select queries\n",
+    "\n",
+    "    \n",
+    "def run_in_transaction(con, sql):\n",
+    "    try:\n",
+    "        cursor = con.cursor()\n",
+    "        cursor.execute(sql);\n",
+    "        con.commit()\n",
+    "        print (\"Query executed successfully!\")\n",
+    "    except (Exception, psycopg2.Error) as error :\n",
+    "        print(\"Error While executing query: \", error)\n",
+    "        con.rollback()\n",
+    "    finally:\n",
+    "        cursor.close()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -360,26 +386,14 @@
    "source": [
     "#Create \"Customer\" Table\n",
     "\n",
-    "try:\n",
-    "    #table_name variable\n",
-    "    customerTable=\"customer\"\n",
-    "    create_customerTablee_query = '''CREATE TABLE '''+ customerTable+''' \n",
-    "              (id INT  PRIMARY KEY     NOT NULL,\n",
-    "               name           TEXT    NOT NULL,\n",
-    "               country        TEXT    NOT NULL,\n",
-    "               email          TEXT   \n",
-    "               ); '''\n",
-    "\n",
-    "    #Execute this command (SQL Query)\n",
-    "    cursor.execute(create_customerTablee_query)\n",
-    "    \n",
-    "    # Make the changes to the database persistent\n",
-    "    con.commit()\n",
-    "    print(\"Table (\"+ customerTable +\") created successfully in PostgreSQL \")\n",
-    "except (Exception, psycopg2.Error) as error:\n",
-    "    # if it exits with an exception the transaction is rolled back.\n",
-    "    con.rollback()\n",
-    "    print(\"Error While Creating the DB: \",error)\n"
+    "run_in_transaction(con, \"\"\"\n",
+    "    CREATE TABLE customer (\n",
+    "        id INT PRIMARY KEY NOT NULL,\n",
+    "        name TEXT NOT NULL,\n",
+    "        country TEXT NOT NULL,\n",
+    "        email TEXT\n",
+    "    );\n",
+    "\"\"\")"
    ]
   },
   {


### PR DESCRIPTION
As suggested by Mr. Riccardo Tommasini I added a helper function `run_in_transaction`, also fixed a bug in docker-version of the homework

It adds the above mentioned function that runs a provided query in a transaction, committing it or rolling it back in the end. This will greatly reduce the amount of boilerplate code that students need to write.

I also fixed an oversight in the docker version of the homework where instead of installing `psycopg2` the cell checked whether it is installed. In a fresh docker container it is not installed, so it makes sense to replace it with `! pip install psycopg2`