### PR TITLE
Fix hostname in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After it is up, add a new connection:
 
 * Name - postgres_default
 * Conn type - postgres
-* Host - postgres
+* Host - localhost
 * Port - 5432
 * Database - airflow
 * Username - airflow


### PR DESCRIPTION
At least for me, the hostname "postgres" didn't work.